### PR TITLE
Add campaign state tracking and /whereami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Per-channel campaign state tracking including title, realm, plot hook, location, players and prompt history.
+- `/whereami` command to recall the current setting.
+- `/campaignstate` debug command to dump channel state.
+- Narration suggestions appended to AI responses.
+- Skill-based `/roll` command and `/save` for saving throws.
+- `/recap` command summarizing recent events.
+- `/set-difficulty` to adjust challenge level.
+- `/inventory view/add/remove` and automatic loot detection.
+
+### Changed
+- `/new_campaign` and `/start_adventure` store structured campaign details.
+- `/act` builds a dynamic system prompt from channel state.
+

--- a/ai_dm_voice_app/README.md
+++ b/ai_dm_voice_app/README.md
@@ -44,8 +44,13 @@ curl -X POST http://localhost:5000/dm -H "Content-Type: application/json" -d '{"
 - Use `/new_campaign [prompt]` in a voice channel to start a campaign and set turn order.
 - The bot will announce the first player and prompt them to act.
 - The current player uses `/act <action>` to take their turn (AI narrates and speaks as before).
+- Narration now ends with 2-3 suggested actions to keep the story moving.
 - When finished, the player uses `/end_turn` to pass to the next player (announced in text and voice).
 - If you try to act out of turn, the bot will remind you to wait.
+- Check your current location: `/whereami`
+- Debug the channel state: `/campaignstate` (ephemeral)
+- Recap recent events: `/recap`
+- Adjust difficulty: `/set-difficulty <easy|normal|hard>` (admin only)
 
 ---
 
@@ -55,6 +60,8 @@ curl -X POST http://localhost:5000/dm -H "Content-Type: application/json" -d '{"
 - View your stats: `/mystats`
 - Set a stat: `/setstat <stat> <value>` (e.g. `/setstat STR 15`)
 - Add to inventory: `/inventory add "Item Name"`
+- Remove from inventory: `/inventory remove "Item"`
+- View inventory: `/inventory view`
 - Character data is stored per Discord user in `/characters/` as JSON files.
 
 ---
@@ -70,6 +77,8 @@ curl -X POST http://localhost:5000/dm -H "Content-Type: application/json" -d '{"
 ## 🎲 Dice Rolling
 
 - Roll dice: `/roll <dice>` (e.g. `/roll 2d6+1`, `/roll 1d20`)
+- Skill check: `/roll athletics` (uses your STR mod, supports --adv/--disadv)
+- Saving throw: `/save WIS vs 14`
 - The bot will also auto-roll if the AI says e.g. "Roll a 1d20" in its response.
 - Dice results are shown in chat and logged.
 - Dice rolls can use character stats and proficiency.
@@ -105,6 +114,7 @@ Find your ElevenLabs voice IDs at https://elevenlabs.io/ and add them here.
 
 ## 🗃️ State Persistence
 - Game state is saved per session (API) or per Discord channel (bot) in the `state/` folder as JSON.
+- Each channel stores its campaign title, realm, plot hook, current location, player list and recent prompt history.
 - You can delete these files to reset a session.
 
 ---

--- a/ai_dm_voice_app/test_setup.py
+++ b/ai_dm_voice_app/test_setup.py
@@ -83,7 +83,7 @@ def test_state_manager():
         
         # Test load
         loaded_data = load_state(test_session)
-        if loaded_data == test_data:
+        if all(loaded_data.get(k) == v for k, v in test_data.items()):
             print("✅ State load test passed")
         else:
             print(f"❌ State load test failed: {loaded_data} != {test_data}")

--- a/ai_dm_voice_app/utils/prompt_builder.py
+++ b/ai_dm_voice_app/utils/prompt_builder.py
@@ -1,0 +1,23 @@
+"""Prompt builder utilities for the Discord bot."""
+
+
+def build_system_prompt(state: dict) -> str:
+    """Return a system prompt describing the current campaign state."""
+    title = state.get("campaign_title", "")
+    realm = state.get("realm", "")
+    location = state.get("location", "")
+    plot = state.get("plot_hook", "")
+    difficulty = state.get("difficulty", "normal")
+
+    system_prompt = f"""
+You are the Dungeon Master for a Discord-based D&D-style campaign.
+Tone: {difficulty}.
+
+Campaign Title: {title}
+Realm: {realm}
+Current Location: {location}
+Plot Summary: {plot}
+
+The player is acting in this setting. Maintain consistency with the world and events so far. End your response with 2–3 actions the player could take next.
+"""
+    return system_prompt


### PR DESCRIPTION
## Summary
- track campaign data per channel with defaults
- build system prompts from current state
- parse structured campaign info from OpenAI
- add `/whereami` and `/campaignstate` commands
- update docs and tests
- skill-based `/roll` and `/save` commands
- `/recap` summarization
- difficulty setting and inventory commands with loot parsing

## Testing
- `pip install -r ai_dm_voice_app/requirements.txt`
- `python ai_dm_voice_app/test_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_6859411b1ae88324851998617d85da7e