### PR TITLE
Add simple web portal for character sheets

### DIFF
--- a/ai_dm_voice_app/README.md
+++ b/ai_dm_voice_app/README.md
@@ -20,10 +20,11 @@ A modular, voice-enabled AI Dungeon Master using GPT-4o and ElevenLabs, with Dis
    copy .env.example .env
    # Edit .env and add your API keys
    ```
-4. **Run the Flask API:**
+4. **Run the Flask API and web portal:**
    ```powershell
    python app.py
    ```
+   Visit `http://localhost:5000/portal/` in your browser to view the character portal.
 5. **Run the Discord bot:**
    ```powershell
    python discord_bot.py
@@ -63,6 +64,11 @@ curl -X POST http://localhost:5000/dm -H "Content-Type: application/json" -d '{"
 - Remove from inventory: `/inventory remove "Item"`
 - View inventory: `/inventory view`
 - Character data is stored per Discord user in `/characters/` as JSON files.
+
+### 🌐 Web Portal
+
+When `python app.py` is running, open `http://localhost:5000/portal/` to browse all
+registered characters and view their inventories.
 
 ---
 

--- a/ai_dm_voice_app/app.py
+++ b/ai_dm_voice_app/app.py
@@ -14,6 +14,13 @@ Config.validate()
 
 app = Flask(__name__)
 
+# Register web portal blueprint
+try:
+    from webportal.routes import portal_bp
+    app.register_blueprint(portal_bp, url_prefix='/portal')
+except Exception as e:
+    print(f"Failed to register portal blueprint: {e}")
+
 @app.route('/dm', methods=['POST'])
 def dm():
     data = request.get_json()

--- a/ai_dm_voice_app/webportal/routes.py
+++ b/ai_dm_voice_app/webportal/routes.py
@@ -1,0 +1,34 @@
+"""Routes for the simple web portal."""
+
+from flask import Blueprint, render_template, abort
+import os
+from utils.character_manager import load_character
+from config import Config
+
+def list_all_characters():
+    """Return a list of all stored characters."""
+    files = [f for f in os.listdir(Config.CHARACTERS_DIR) if f.endswith('.json')]
+    characters = []
+    for f in files:
+        char_id = f[:-5]
+        data = load_character(char_id)
+        if data:
+            characters.append({
+                'id': char_id,
+                'name': data.get('name', char_id),
+            })
+    return characters
+
+portal_bp = Blueprint('portal', __name__, template_folder='templates')
+
+@portal_bp.route('/')
+def list_characters():
+    characters = list_all_characters()
+    return render_template('character_list.html', characters=characters)
+
+@portal_bp.route('/character/<char_id>')
+def character_detail(char_id: str):
+    data = load_character(char_id)
+    if not data:
+        abort(404)
+    return render_template('character_detail.html', char=data, char_id=char_id)

--- a/ai_dm_voice_app/webportal/templates/character_detail.html
+++ b/ai_dm_voice_app/webportal/templates/character_detail.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ char.name }}</title>
+</head>
+<body>
+    <h1>{{ char.name }}</h1>
+    <p><strong>Class:</strong> {{ char.class }}</p>
+    <p><strong>Race:</strong> {{ char.race }}</p>
+    <p><strong>Level:</strong> {{ char.level }}</p>
+    <p><strong>HP:</strong> {{ char.hp }}/{{ char.max_hp }}</p>
+    <h2>Abilities</h2>
+    <ul>
+    {% for stat in ['STR','DEX','CON','INT','WIS','CHA'] %}
+        <li>{{ stat }}: {{ char[stat] }}</li>
+    {% endfor %}
+    </ul>
+    <h2>Inventory</h2>
+    {% if char.inventory %}
+    <ul>
+    {% for item in char.inventory %}
+        <li>{{ item }}</li>
+    {% endfor %}
+    </ul>
+    {% else %}
+    <p>No items.</p>
+    {% endif %}
+    <p><a href="{{ url_for('portal.list_characters') }}">Back to list</a></p>
+</body>
+</html>

--- a/ai_dm_voice_app/webportal/templates/character_list.html
+++ b/ai_dm_voice_app/webportal/templates/character_list.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Character List</title>
+</head>
+<body>
+    <h1>Character List</h1>
+    <ul>
+    {% for c in characters %}
+        <li><a href="{{ url_for('portal.character_detail', char_id=c.id) }}">{{ c.name }}</a></li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask blueprint under `webportal/` with routes to list characters and show character details
- register the blueprint with url prefix in `app.py`
- document how to access the portal in the README
- handle multiple character files

## Testing
- `pip install -r ai_dm_voice_app/requirements.txt`
- `python ai_dm_voice_app/test_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_685944cf8ff483249972f158a88ba0fc