### PR TITLE
Implement story manager and REST API

### DIFF
--- a/ai_dm_voice_app/README.md
+++ b/ai_dm_voice_app/README.md
@@ -1,6 +1,6 @@
 # ai_dm_voice_app
 
-A modular, voice-enabled AI Dungeon Master using GPT-4o and ElevenLabs, with Discord support and persistent campaign state.
+A modular, voice-enabled AI Dungeon Master using GPT-4o and ElevenLabs, with Discord support, a REST story API and persistent campaign state.
 
 ---
 
@@ -37,8 +37,16 @@ A modular, voice-enabled AI Dungeon Master using GPT-4o and ElevenLabs, with Dis
 
 **Sample curl:**
 ```bash
-curl -X POST http://localhost:5000/dm -H "Content-Type: application/json" -d '{"input": "The party enters the tavern."}' --output response.mp3
+curl -X POST http://localhost:5000/api/story/start \
+     -H "Content-Type: application/json" \
+     -d '{"story_id": "my-story", "genre": "fantasy", "prompt": "A dark forest"}'
+
+curl -X POST http://localhost:5000/api/story/continue \
+     -H "Content-Type: application/json" \
+     -d '{"story_id": "my-story", "action_type": "do", "prompt": "light a torch"}'
 ```
+
+The legacy `/dm` endpoint still works for voice mode.
 
 ### Discord
 - Invite your bot to your server.

--- a/ai_dm_voice_app/app.py
+++ b/ai_dm_voice_app/app.py
@@ -1,9 +1,11 @@
 from flask import Flask, request, jsonify, send_file, make_response
-from services.openai_service import get_dm_response
+from services.openai_service import get_dm_response, generate_text
 from services.elevenlabs_service import text_to_speech
 from utils.voice_parser import extract_voice_tag, clean_text
 from utils.voice_map import get_voice_id
 from utils.state_manager import load_state, save_state
+from services.story_manager import StoryManager
+from services.context_manager import ContextManager
 import os
 from dotenv import load_dotenv
 import tempfile
@@ -13,6 +15,10 @@ load_dotenv()
 Config.validate()
 
 app = Flask(__name__)
+
+# Managers for new storytelling API
+story_manager = StoryManager()
+context_manager = ContextManager()
 
 # Register web portal blueprint
 try:
@@ -52,6 +58,58 @@ def dm():
     response.headers['X-Text'] = text
     response.headers['X-Voice-Tag'] = voice_tag or 'Narrator'
     return response
+
+
+# --- New Storytelling API ---
+
+@app.route('/api/story/start', methods=['POST'])
+def start_story():
+    data = request.json or {}
+    story_id = data.get('story_id')
+    genre = data.get('genre', 'fantasy')
+    prompt = data.get('prompt', '')
+    if not story_id or not prompt:
+        return jsonify({'error': 'story_id and prompt required'}), 400
+
+    story_manager.create_story(story_id, genre, prompt)
+    ai_text = generate_text(prompt, action_type='story', genre=genre)
+    story_manager.add_turn(story_id, 'story', prompt, ai_text)
+    return jsonify({'story_id': story_id, 'text': ai_text})
+
+
+@app.route('/api/story/continue', methods=['POST'])
+def continue_story():
+    data = request.json or {}
+    story_id = data.get('story_id')
+    prompt = data.get('prompt', '')
+    action_type = data.get('action_type', 'continue')
+    if not story_id or not prompt:
+        return jsonify({'error': 'story_id and prompt required'}), 400
+
+    story = story_manager.stories.get(story_id)
+    if not story:
+        return jsonify({'error': 'Story not found'}), 404
+    context = context_manager.build_context(story['turns'])
+    ai_text = generate_text(prompt, action_type=action_type, story_context=context, genre=story.get('genre'))
+    story_manager.add_turn(story_id, action_type, prompt, ai_text)
+    return jsonify({'story_id': story_id, 'text': ai_text})
+
+
+@app.route('/api/generate', methods=['POST'])
+def generate():
+    data = request.json or {}
+    prompt = data.get('prompt', '')
+    action_type = data.get('action_type', 'continue')
+    story_context = data.get('context', '')
+    genre = data.get('genre', 'fantasy')
+    if not prompt:
+        return jsonify({'error': 'No prompt provided'}), 400
+    try:
+        generated_text = generate_text(prompt, action_type, story_context, genre)
+        return jsonify({'text': generated_text})
+    except Exception as e:
+        app.logger.error(f'Error generating text: {str(e)}')
+        return jsonify({'error': 'Failed to generate text'}), 500
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/ai_dm_voice_app/services/context_manager.py
+++ b/ai_dm_voice_app/services/context_manager.py
@@ -1,0 +1,30 @@
+class ContextManager:
+    """Build conversation context from recent turns."""
+
+    def __init__(self, max_turns=20, max_tokens=2000):
+        self.max_turns = max_turns
+        self.max_tokens = max_tokens
+
+    def build_context(self, turns):
+        selected = turns[-self.max_turns:]
+        context_lines = []
+        token_count = 0
+        for turn in reversed(selected):
+            lines = [
+                f"Player ({turn.get('action_type','')}): {turn.get('user_input','')}",
+                f"DM: {turn.get('ai_response','')}"
+            ]
+            tokens = sum(len(l.split()) for l in lines)
+            if token_count + tokens > self.max_tokens:
+                break
+            context_lines = lines + context_lines
+            token_count += tokens
+        return "\n".join(context_lines)
+
+    def summarize(self, turns):
+        """Placeholder for summarizing characters, locations, and events."""
+        return {
+            "characters": [],
+            "locations": [],
+            "items": [],
+        }

--- a/ai_dm_voice_app/services/story_manager.py
+++ b/ai_dm_voice_app/services/story_manager.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+class StoryManager:
+    """Manage multiple interactive stories."""
+
+    def __init__(self):
+        self.stories = {}
+
+    def create_story(self, story_id, genre, initial_prompt):
+        """Create a new story with metadata and initial context."""
+        self.stories[story_id] = {
+            "genre": genre,
+            "created_at": datetime.utcnow().isoformat(),
+            "context": initial_prompt,
+            "turns": [],
+            "metadata": {
+                "characters": [],
+                "locations": [],
+                "items": [],
+            },
+        }
+        return self.stories[story_id]
+
+    def add_turn(self, story_id, action_type, user_input, ai_response):
+        story = self.stories.get(story_id)
+        if not story:
+            raise ValueError("Story not found")
+        story["turns"].append(
+            {
+                "action_type": action_type,
+                "user_input": user_input,
+                "ai_response": ai_response,
+            }
+        )
+
+    def get_context(self, story_id, max_turns=10):
+        story = self.stories.get(story_id)
+        if not story:
+            return ""
+        turns = story["turns"][-max_turns:]
+        lines = []
+        for t in turns:
+            if t["action_type"] == "say":
+                prefix = "Player says"
+            elif t["action_type"] == "do":
+                prefix = "Player attempts"
+            else:
+                prefix = "Player"
+            lines.append(f"{prefix}: {t['user_input']}")
+            lines.append(f"DM: {t['ai_response']}")
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add `StoryManager` and `ContextManager` helpers
- overhaul system prompt and text generation in `openai_service`
- expose new `/api/story` routes and `/api/generate`
- document story API usage

## Testing
- `python -m py_compile ai_dm_voice_app/services/openai_service.py`


------
https://chatgpt.com/codex/tasks/task_e_685f26486f808324b4445ad5b93886b3