### PR TITLE
Improve campaign narration formatting

### DIFF
--- a/ai_dm_voice_app/discord_bot.py
+++ b/ai_dm_voice_app/discord_bot.py
@@ -408,7 +408,7 @@ async def new_campaign(interaction: discord.Interaction, prompt: str = ""):
     first_player_id = turn_order[0]
     first_player_mention = f"<@{first_player_id}>"
     await interaction.followup.send(
-        f"**New Campaign - {state.get('campaign_title','')}**\n{campaign_text}\n\n{first_player_mention}, it's your turn. What do you do?"
+        f"{campaign_text}\n\n{first_player_mention}, it's your turn. What do you do?"
     )
     
     # Play audio if possible
@@ -520,7 +520,6 @@ async def act(interaction: discord.Interaction, action: str):
     await interaction.followup.send(output)
     for item in loot_items:
         add_inventory(current_player_id, item)
-        await interaction.followup.send(f"🧳 {interaction.user.display_name} picks up a '{item}' → Added to inventory")
 
     if state.get("auto_advance"):
         idx = get_current_turn_index(updated_state)
@@ -599,7 +598,7 @@ async def start_adventure(interaction: discord.Interaction, prompt: str = ""):
         print(f"TTS Error: {e}")
         audio_bytes = None
     
-    await interaction.followup.send(f"**New Adventure:**\n{campaign_text}")
+    await interaction.followup.send(campaign_text)
     log_message(channel_id, "DM", f"New adventure started: {campaign_text}")
     
     # Play audio if possible

--- a/ai_dm_voice_app/services/openai_service.py
+++ b/ai_dm_voice_app/services/openai_service.py
@@ -151,7 +151,18 @@ def generate_campaign(state, prompt=None):
         "prompt_history": [],
     })
 
-    return data.get("intro", campaign_text), state
+    formatted = (
+        "=== NEW CAMPAIGN CREATED ===\n"
+        f"Title: {state['campaign_title']}\n"
+        f"Realm: {state['realm']}\n"
+        f"Starting Location: {state['location']}\n\n"
+        "[Plot Hook]\n"
+        f"{state['plot_hook']}\n\n"
+        "[Introduction]\n"
+        f"{data.get('intro', campaign_text)}"
+    )
+
+    return formatted, state
 
 
 def summarize_history(state, max_entries=10):


### PR DESCRIPTION
## Summary
- format campaign data into a readable narrative in `generate_campaign`
- send formatted text from `/new_campaign` and `/start_adventure`
- avoid duplicate loot messages when acting

## Testing
- `python -m py_compile ai_dm_voice_app/discord_bot.py ai_dm_voice_app/services/openai_service.py`


------
https://chatgpt.com/codex/tasks/task_e_686129bf789c8324af29c90d0957fa88